### PR TITLE
Considerar tributação otimista para nº de meses

### DIFF
--- a/public/js/calculadora.js
+++ b/public/js/calculadora.js
@@ -49,11 +49,11 @@ $().ready(function () {
 
     function getIndexIR() {
         var periodo = $("#period").val();
-        if (periodo <= 6) {
+        if (periodo < 6) {
             return 22.5;
-        } else if (periodo <= 12) {
+        } else if (periodo < 12) {
             return 20;
-        } else if (periodo <= 24) {
+        } else if (periodo < 24) {
             return 17.5;
         } else {
             return 15;


### PR DESCRIPTION
A lógica é simples: a tabela regressiva não é de fato baseada em meses, mas em dias. Por exemplo, a tributação mínima se após passar de 720 dias, não 24 meses. Como qualquer intervalo vai conter um número suficiente de meses de 31 dias, é garantido que seu investimento cairá na menor faixa de tributação daquele intervalo.

(E isso na prática sempre acontece: qualquer CDB de 2 anos vai vencer sempre em 721-730 dias, nenhum banco vai cometer a besteira de desvalorizar seu produto colocando um prazo de 719 dias.)